### PR TITLE
Makes the plugin steps option optional (both dereferences default to []), rewrites the Quick Start to import and pass the built-in step tasks from /server, and — per review — lands the publishConfig fix alongside, deleting the block that stripped ./server from the published exports so the enriched sample resolves at install time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ npm install @xtr-dev/payload-automation
 
 ```typescript
 import { buildConfig } from 'payload'
-import { workflowsPlugin } from '@xtr-dev/payload-automation/server'
+import {
+  workflowsPlugin,
+  HttpRequestStepTask,
+  CreateDocumentStepTask,
+  ReadDocumentStepTask,
+  UpdateDocumentStepTask,
+  DeleteDocumentStepTask,
+  SendEmailStepTask,
+} from '@xtr-dev/payload-automation/server'
 
 export default buildConfig({
   // ... your config
@@ -41,6 +49,16 @@ export default buildConfig({
           update: true
         }
       },
+      // Step types available to workflows. The built-in tasks are not
+      // registered automatically — pass the ones you want to use.
+      steps: [
+        HttpRequestStepTask,
+        CreateDocumentStepTask,
+        ReadDocumentStepTask,
+        UpdateDocumentStepTask,
+        DeleteDocumentStepTask,
+        SendEmailStepTask,
+      ],
       enabled: true,
     }),
   ],
@@ -447,8 +465,11 @@ interface WorkflowsPluginConfig {
     [globalSlug: string]: boolean | { /* hooks */ }
   }
 
-  // Custom step definitions
-  steps?: StepDefinition[]
+  // Step types available to workflows (Payload TaskConfig objects).
+  // Optional — without it the plugin registers its collections and hooks
+  // but no step types. Built-in tasks are exported from
+  // '@xtr-dev/payload-automation/server'.
+  steps?: TaskConfig[]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -34,11 +34,6 @@
       "import": "./dist/exports/server.js",
       "types": "./dist/exports/server.d.ts",
       "default": "./dist/exports/server.js"
-    },
-    "./helpers": {
-      "import": "./dist/exports/helpers.js",
-      "types": "./dist/exports/helpers.d.ts",
-      "default": "./dist/exports/helpers.js"
     }
   },
   "main": "dist/index.js",
@@ -104,27 +99,6 @@
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
     "pnpm": "^9 || ^10"
-  },
-  "publishConfig": {
-    "exports": {
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "./client": {
-        "import": "./dist/exports/client.js",
-        "types": "./dist/exports/client.d.ts",
-        "default": "./dist/exports/client.js"
-      },
-      "./rsc": {
-        "import": "./dist/exports/rsc.js",
-        "types": "./dist/exports/rsc.d.ts",
-        "default": "./dist/exports/rsc.js"
-      }
-    },
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src/plugin/config-types.ts
+++ b/src/plugin/config-types.ts
@@ -71,8 +71,12 @@ export type WorkflowsPluginConfig<
     /**
      * Step task configurations.
      * These are the step types available for use in workflows.
+     * Optional: without it the plugin still registers its collections and
+     * trigger hooks, but no step types exist until some are passed in.
+     * The built-in tasks (HttpRequestStepTask etc.) are exported from
+     * '@xtr-dev/payload-automation/server' and must be passed explicitly.
      */
-    steps: TaskConfig<string>[]
+    steps?: TaskConfig<string>[]
 
     /**
      * Seed workflows to create on plugin initialization.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -22,7 +22,7 @@ const applyCollectionsConfig = <T extends string>(
   // Add all automation collections
   config.collections.push(
     createTriggersCollection(pluginOptions),
-    createStepsCollection(pluginOptions.steps),
+    createStepsCollection(pluginOptions.steps ?? []),
     createWorkflowCollection(),
     WorkflowRunsCollection
   )
@@ -158,7 +158,7 @@ export const workflowsPlugin =
       config.jobs = { tasks: [] }
     }
 
-    for (const step of pluginOptions.steps) {
+    for (const step of pluginOptions.steps ?? []) {
       if (!config.jobs?.tasks?.find(task => task.slug === step.slug)) {
         config.jobs?.tasks?.push(step)
       }


### PR DESCRIPTION
Original scope: WorkflowsPluginConfig required steps while the README Quick Start omitted it, so the documented sample threw at config time. steps is now steps?: TaskConfig<string>[], the two dereferences in src/plugin/index.ts default to [], and the Quick Start imports the six built-in step tasks from @xtr-dev/payload-automation/server and passes them explicitly, since nothing registers them automatically. The configuration section now names the real TaskConfig type instead of the nonexistent StepDefinition.

Added this round, answering review comment rmst0l6ov0: the enriched Quick Start grows the sample's dependence on the ./server subpath from one imported name to seven, and publishConfig.exports overrode the export map at publish time with a copy listing only ., ./client and ./rsc — so the sample would have failed at install time instead of config time (invariant rllh5dm). Rather than re-authoring, I cherry-picked 2472e4f from fix/publishconfig-strips-server-subpath, which already fixes exactly this: it deletes the publishConfig block entirely (deletion beats syncing — the block's main/types merely duplicated the top-level fields, so it added nothing but a second copy to keep in step) and drops the ./helpers subpath, which points at dist/exports/helpers.js that no source file can ever produce. Cherry-picking keeps the two branches carrying the identical patch, so they merge cleanly in either order. Verified by reading src/exports/server.ts that all seven names the Quick Start imports (workflowsPlugin plus the six step tasks) are exported there; install-level verification (pack + scratch install) isn't possible in this environment.