### PR TITLE
Update Claude Code workflows to claude-code-action v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,77 +2,60 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Skip drafts and PRs explicitly opted out of review
+    if: |
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.title, '[skip-review]') &&
+      !contains(github.event.pull_request.title, '[WIP]')
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-    
+      actions: read
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
+            Review this pull request to the PayloadCMS automation plugin and provide feedback on:
+            - Code quality and adherence to the conventions in CLAUDE.md
+            - Potential bugs or issues, especially in the workflow executor and expression engine
+            - Correct use of PayloadCMS APIs (TaskConfig, collections, hooks)
             - Performance considerations
-            - Security concerns
+            - Security concerns, particularly around JSONata expression evaluation and HTTP steps
             - Test coverage
-            
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
+
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
-
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,46 +19,41 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-          
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-          
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
 
+          claude_args: |
+            --allowedTools "Bash(pnpm install),Bash(pnpm build),Bash(pnpm build:*),Bash(pnpm lint),Bash(pnpm lint:*),Bash(pnpm test),Bash(pnpm test:*)"
+            --append-system-prompt "This repository is a PayloadCMS automation plugin. Follow CLAUDE.md: use pnpm, keep TypeScript strict, and prefer JSONata for expression evaluation. Run pnpm lint and pnpm test:int before proposing changes."


### PR DESCRIPTION
Both Claude workflows were still on `anthropics/claude-code-action@beta` with v0.x inputs (`direct_prompt`, `allowed_tools`, `model`, `custom_instructions`), which no longer exist. This migrates them to `@v1` and tailors them to this repo.

## `.github/workflows/claude.yml` (@claude mention handler)

- `anthropics/claude-code-action@beta` → `@v1`, `actions/checkout@v4` → `@v6`
- Permissions raised to `contents: write`, `pull-requests: write`, `issues: write` — v1 needs these to comment and push commits
- Replaced the commented-out `allowed_tools` / `custom_instructions` placeholders with a real `claude_args` block: `--allowedTools` scoped to the repo's pnpm scripts, and `--append-system-prompt` pointing at the CLAUDE.md conventions
- Added pnpm + Node 20 setup and `pnpm install --frozen-lockfile` so lint/test/build actually run

## `.github/workflows/claude-code-review.yml` (automated PR review)

- `@beta` → `@v1`, `actions/checkout@v4` → `@v6`
- `direct_prompt` → `prompt`, now carrying `REPO` / `PR NUMBER` context and review focus areas specific to this plugin (workflow executor, expression engine, PayloadCMS `TaskConfig` usage, JSONata sandboxing)
- `track_progress: true` for progress-tracking comments
- `claude_args: --allowedTools` enables `mcp__github_inline_comment__create_inline_comment` plus the `gh pr` commands, so feedback lands as inline PR comments instead of chat output
- Triggers extended to `ready_for_review` and `reopened`; the previously commented-out skip conditions are now live — drafts and PRs titled `[WIP]` / `[skip-review]` are skipped
- `pull-requests: write` / `issues: write` required for posting comments

Authentication continues to use the existing `CLAUDE_CODE_OAUTH_TOKEN` secret. `publish.yml` is unchanged.

Both files parse as valid YAML.

---
_Generated by [Claude Code](https://claude.ai/code/session_019uuJPhGzUU5skGs1hdBuwr)_