### PR TITLE
Mark @payloadcms/ui as an optional peer dependency so server-only consumers of ./server don't get an unmet-peer warning for a package they never import.

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
     "@payloadcms/ui": "^3.79.1",
     "payload": "^3.79.1"
   },
+  "peerDependenciesMeta": {
+    "@payloadcms/ui": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
     "pnpm": "^9 || ^10"

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
+    "@payloadcms/ui": "^3.79.1",
     "payload": "^3.79.1"
   },
   "engines": {


### PR DESCRIPTION
The previous commit on this branch added @payloadcms/ui as a required peerDependency. That's correct for the client/fields/views subpaths, but consumers who only import from ./server (workflowsPlugin, WorkflowExecutor, step handlers) never touch @payloadcms/ui or React — confirmed no such import exists in src/exports/server.ts. Requiring it as a peer regardless gives those consumers an unmet-peer-dependency warning for a package they'll never install.

Fix: add peerDependenciesMeta so @payloadcms/ui is declared but optional, same as the existing pattern would suggest. Only @payloadcms/ui is marked optional here — react isn't a peer dependency on this branch at all, so there's nothing to mark for it.