### PR TITLE
Fix a misleading comment in publish.yml claiming npm publish uses the dist/ left by test:pack-types, when prepublishOnly rebuilds it from scratch right before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Run tests
         run: pnpm test:int
 
+      # Builds dist/ itself (pnpm clean && pnpm build) before packing, so the
+      # dist/ it leaves behind is already what `npm publish` needs — a
+      # separate Build step here would just rebuild identical output.
       - name: Verify published types (pack & consume)
         run: pnpm test:pack-types
-
-      - name: Build
-        run: pnpm build
 
       - name: Check if should publish
         id: version-check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run tests
         run: pnpm test:int
 
+      - name: Verify published types (pack & consume)
+        run: pnpm test:pack-types
+
       - name: Build
         run: pnpm build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,13 @@ jobs:
       - name: Run tests
         run: pnpm test:int
 
-      # Builds dist/ itself (pnpm clean && pnpm build) before packing, so the
-      # dist/ it leaves behind is already what `npm publish` needs — a
-      # separate Build step here would just rebuild identical output.
+      # Builds dist/ itself (pnpm clean && pnpm build) before packing, so a
+      # separate Build step here would just rebuild identical output before
+      # this one does it again. Note this step's dist/ is NOT what gets
+      # published: package.json's prepublishOnly (pnpm clean && pnpm build)
+      # runs again right before `npm publish` below, rebuilding from scratch.
+      # This step exists to catch a types/exports regression before publish,
+      # not to produce the artifact that ships.
       - name: Verify published types (pack & consume)
         run: pnpm test:pack-types
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "prepublishOnly": "pnpm clean && pnpm build",
     "test": "pnpm test:int && pnpm test:e2e",
     "test:e2e": "playwright test",
-    "test:int": "vitest"
+    "test:int": "vitest",
+    "test:pack-types": "node --test test/main-entry-types.test.mjs"
   },
   "devDependencies": {
     "@payloadcms/db-mongodb": "3.81.0",

--- a/test/main-entry-types.test.mjs
+++ b/test/main-entry-types.test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const run = async (command, args, options) => {
+  await new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, { ...options, stdio: 'inherit' })
+    child.on('error', reject)
+    child.on('exit', (code, signal) => {
+      if (code === 0) resolvePromise()
+      else reject(new Error(`${command} ${args.join(' ')} exited with ${signal ?? `code ${code}`}`))
+    })
+  })
+}
+
+const packageName = '@xtr-dev/payload-automation'
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+// The names src/index.ts documents as the public main-entry contract. Kept
+// as a literal list, not derived from src/index.ts, so a change there that
+// silently drops a name still leaves this test importing it and failing.
+const mainEntryTypeNames = [
+  'Workflow',
+  'ResolvedStep',
+  'StepResult',
+  'WorkflowJobMeta',
+  'CustomTriggerOptions',
+  'ExecutionContext',
+  'TriggerResult',
+  'SeedWorkflow',
+  'WorkflowLoggingConfig',
+  'WorkflowsPluginConfig',
+]
+
+test(
+  "the main entry's exported types resolve and compile, against the declared peer floor, from a clean pack-and-install",
+  { timeout: 5 * 60 * 1000 },
+  async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), 'payload-automation-main-entry-types-'))
+    const packDirectory = join(temporaryRoot, 'pack')
+    const consumerDirectory = join(temporaryRoot, 'consumer')
+
+    try {
+      await mkdir(packDirectory)
+      await mkdir(consumerDirectory)
+
+      // The real publish path: pnpm build (types then swc), not a
+      // hand-picked subset of it, so this fails the way a real `pnpm
+      // publish` would rather than the way a partial build would.
+      await run('pnpm', ['clean'], { cwd: projectRoot })
+      await run('pnpm', ['build'], { cwd: projectRoot })
+      await run('pnpm', ['pack', '--pack-destination', packDirectory], { cwd: projectRoot })
+
+      const tarballNames = (await readdir(packDirectory)).filter((name) => name.endsWith('.tgz'))
+      assert.equal(tarballNames.length, 1, 'pnpm pack should produce exactly one tarball')
+      const tarball = join(packDirectory, tarballNames[0])
+
+      const sourcePackageJson = JSON.parse(await readFile(join(projectRoot, 'package.json'), 'utf8'))
+      // The declared peer floor, not whatever payload happens to be in this
+      // repo's own node_modules - a consumer sitting on the oldest payload
+      // the peerDependencies range allows is exactly who a types mismatch
+      // like the README's stale ^3.37.0 claim (fixed separately) would hit.
+      const peerFloor = sourcePackageJson.peerDependencies.payload.replace(/^[^0-9]*/, '')
+      const typescriptVersion = sourcePackageJson.devDependencies.typescript
+
+      await writeFile(
+        join(consumerDirectory, 'package.json'),
+        JSON.stringify({
+          name: 'main-entry-types-consumer',
+          private: true,
+          type: 'module',
+          packageManager: sourcePackageJson.packageManager,
+          dependencies: {
+            [packageName]: `file:${tarball}`,
+            payload: peerFloor,
+          },
+          devDependencies: {
+            typescript: typescriptVersion,
+          },
+        }),
+      )
+
+      await writeFile(
+        join(consumerDirectory, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'Bundler',
+            strict: true,
+            skipLibCheck: true,
+            noEmit: true,
+          },
+          include: ['check-types.ts'],
+        }),
+      )
+
+      await writeFile(
+        join(consumerDirectory, 'check-types.ts'),
+        `import type {\n${mainEntryTypeNames.map((name) => `  ${name},`).join('\n')}\n} from ${JSON.stringify(
+          packageName,
+        )}\n\n` +
+          `export type AllMainEntryTypes = [\n${mainEntryTypeNames.map((name) => `  ${name},`).join('\n')}\n]\n`,
+      )
+
+      await run('pnpm', ['install', '--ignore-scripts'], { cwd: consumerDirectory })
+      await run('pnpm', ['exec', 'tsc', '--noEmit'], { cwd: consumerDirectory })
+    } finally {
+      await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  },
+)


### PR DESCRIPTION
A reviewer pointed out that the comment justifying the removal of the standalone Build step was wrong about *why* it's safe to remove: it claimed the dist/ produced by the test:pack-types step is "already what npm publish needs," but package.json's prepublishOnly script (pnpm clean && pnpm build) runs again immediately before npm publish, with no --ignore-scripts anywhere in the workflow to suppress it. So the dist/ left behind by test:pack-types is wiped and rebuilt one more time by npm itself before the tarball is actually published.

The removal of the standalone Build step is still correct — it really was a redundant third build with nothing meaningful between it and test:pack-types (and now also nothing meaningful between it and the prepublishOnly hook). Only the reasoning in the comment was wrong. Rewrote it to say what the pack-types step is actually for (catching a types/exports regression pre-publish) and to explicitly call out that prepublishOnly rebuilds dist/ again before the real publish happens, so the next person reading this doesn't draw the same wrong conclusion.