### PR TITLE
Deletes publishConfig from package.json, whose exports override stripped ./server, ./fields and ./views from the published package — the README Quick Start imports from /server, so the documented install failed. Also drops the ./helpers export, which pointed at a file the build cannot emit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,6 @@
       "import": "./dist/exports/server.js",
       "types": "./dist/exports/server.d.ts",
       "default": "./dist/exports/server.js"
-    },
-    "./helpers": {
-      "import": "./dist/exports/helpers.js",
-      "types": "./dist/exports/helpers.d.ts",
-      "default": "./dist/exports/helpers.js"
     }
   },
   "main": "dist/index.js",
@@ -104,27 +99,6 @@
   "engines": {
     "node": "^18.20.2 || >=20.9.0",
     "pnpm": "^9 || ^10"
-  },
-  "publishConfig": {
-    "exports": {
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "./client": {
-        "import": "./dist/exports/client.js",
-        "types": "./dist/exports/client.d.ts",
-        "default": "./dist/exports/client.js"
-      },
-      "./rsc": {
-        "import": "./dist/exports/rsc.js",
-        "types": "./dist/exports/rsc.d.ts",
-        "default": "./dist/exports/rsc.js"
-      }
-    },
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
npm replaces top-level fields with publishConfig equivalents at publish time. Here publishConfig.exports was a stale copy of the export map listing only ".", "./client" and "./rsc", so every publish shipped without "./server", "./fields" and "./views" — and the README tells every user to import the plugin from '@xtr-dev/payload-automation/server' (lines 31 and 54). The issue offered two fixes: sync publishConfig.exports with exports, or delete it. I deleted the whole publishConfig block rather than syncing it, because its other two keys (main, types) merely duplicated the top-level fields — the block said nothing the top level did not already say, and keeping a second copy of the export map is how this drift happened in the first place.

Separately, the top-level exports named "./helpers" pointing at dist/exports/helpers.js, but src/exports/ contains only client, fields, rsc, server and views — no helpers.ts exists, so the build can never emit that file and the subpath could never resolve. Dropped the entry rather than creating a source file, since nothing in the README or docs references /helpers and there is nothing for such a file to export. Verified after the edit that all six remaining subpaths map to an existing source file under src/, that the JSON still parses, and that no other file in the repo references publishConfig or the /helpers subpath. I could not verify against a packed tarball (npm registry access needs interactive approval here), but publish metadata is determined entirely by package.json, which is what changed.